### PR TITLE
Add old groovy versions now hosted at bintray.

### DIFF
--- a/groovy/groovy_1_8_9.js
+++ b/groovy/groovy_1_8_9.js
@@ -1,0 +1,2 @@
+//push new version
+db.candidates.update({candidate:"groovy"}, {"$push": {versions: {version: "1.8.9", url: "http://dl.bintray.com/groovy/maven/groovy-binary-1.8.9.zip"}}});

--- a/groovy/groovy_2_0_0.js
+++ b/groovy/groovy_2_0_0.js
@@ -1,0 +1,2 @@
+//push new version
+db.candidates.update({candidate:"groovy"}, {"$push": {versions: {version: "2.0.0", url: "http://dl.bintray.com/groovy/maven/groovy-binary-2.0.0.zip"}}});

--- a/groovy/groovy_2_0_1.js
+++ b/groovy/groovy_2_0_1.js
@@ -1,0 +1,2 @@
+//push new version
+db.candidates.update({candidate:"groovy"}, {"$push": {versions: {version: "2.0.1", url: "http://dl.bintray.com/groovy/maven/groovy-binary-2.0.1.zip"}}});

--- a/groovy/groovy_2_0_2.js
+++ b/groovy/groovy_2_0_2.js
@@ -1,0 +1,2 @@
+//push new version
+db.candidates.update({candidate:"groovy"}, {"$push": {versions: {version: "2.0.2", url: "http://dl.bintray.com/groovy/maven/groovy-binary-2.0.2.zip"}}});

--- a/groovy/groovy_2_0_3.js
+++ b/groovy/groovy_2_0_3.js
@@ -1,0 +1,2 @@
+//push new version
+db.candidates.update({candidate:"groovy"}, {"$push": {versions: {version: "2.0.3", url: "http://dl.bintray.com/groovy/maven/groovy-binary-2.0.3.zip"}}});

--- a/groovy/groovy_2_0_4.js
+++ b/groovy/groovy_2_0_4.js
@@ -1,0 +1,2 @@
+//push new version
+db.candidates.update({candidate:"groovy"}, {"$push": {versions: {version: "2.0.4", url: "http://dl.bintray.com/groovy/maven/groovy-binary-2.0.4.zip"}}});

--- a/groovy/groovy_2_0_5.js
+++ b/groovy/groovy_2_0_5.js
@@ -1,0 +1,2 @@
+//push new version
+db.candidates.update({candidate:"groovy"}, {"$push": {versions: {version: "2.0.5", url: "http://dl.bintray.com/groovy/maven/groovy-binary-2.0.5.zip"}}});

--- a/groovy/groovy_2_0_6.js
+++ b/groovy/groovy_2_0_6.js
@@ -1,0 +1,2 @@
+//push new version
+db.candidates.update({candidate:"groovy"}, {"$push": {versions: {version: "2.0.6", url: "http://dl.bintray.com/groovy/maven/groovy-binary-2.0.6.zip"}}});

--- a/groovy/groovy_2_0_7.js
+++ b/groovy/groovy_2_0_7.js
@@ -1,0 +1,2 @@
+//push new version
+db.candidates.update({candidate:"groovy"}, {"$push": {versions: {version: "2.0.7", url: "http://dl.bintray.com/groovy/maven/groovy-binary-2.0.7.zip"}}});

--- a/groovy/groovy_2_0_8.js
+++ b/groovy/groovy_2_0_8.js
@@ -1,0 +1,2 @@
+//push new version
+db.candidates.update({candidate:"groovy"}, {"$push": {versions: {version: "2.0.8", url: "http://dl.bintray.com/groovy/maven/groovy-binary-2.0.8.zip"}}});

--- a/groovy/groovy_2_1_0.js
+++ b/groovy/groovy_2_1_0.js
@@ -1,0 +1,2 @@
+//push new version
+db.candidates.update({candidate:"groovy"}, {"$push": {versions: {version: "2.1.0", url: "http://dl.bintray.com/groovy/maven/groovy-binary-2.1.0.zip"}}});

--- a/groovy/groovy_2_1_1.js
+++ b/groovy/groovy_2_1_1.js
@@ -1,0 +1,2 @@
+//push new version
+db.candidates.update({candidate:"groovy"}, {"$push": {versions: {version: "2.1.1", url: "http://dl.bintray.com/groovy/maven/groovy-binary-2.1.1.zip"}}});

--- a/groovy/groovy_2_1_2.js
+++ b/groovy/groovy_2_1_2.js
@@ -1,0 +1,2 @@
+//push new version
+db.candidates.update({candidate:"groovy"}, {"$push": {versions: {version: "2.1.2", url: "http://dl.bintray.com/groovy/maven/groovy-binary-2.1.2.zip"}}});

--- a/groovy/groovy_2_1_3.js
+++ b/groovy/groovy_2_1_3.js
@@ -1,0 +1,2 @@
+//push new version
+db.candidates.update({candidate:"groovy"}, {"$push": {versions: {version: "2.1.3", url: "http://dl.bintray.com/groovy/maven/groovy-binary-2.1.3.zip"}}});

--- a/groovy/groovy_2_1_4.js
+++ b/groovy/groovy_2_1_4.js
@@ -1,0 +1,2 @@
+//push new version
+db.candidates.update({candidate:"groovy"}, {"$push": {versions: {version: "2.1.4", url: "http://dl.bintray.com/groovy/maven/groovy-binary-2.1.4.zip"}}});

--- a/groovy/groovy_2_1_5.js
+++ b/groovy/groovy_2_1_5.js
@@ -1,0 +1,2 @@
+//push new version
+db.candidates.update({candidate:"groovy"}, {"$push": {versions: {version: "2.1.5", url: "http://dl.bintray.com/groovy/maven/groovy-binary-2.1.5.zip"}}});

--- a/groovy/groovy_2_1_6.js
+++ b/groovy/groovy_2_1_6.js
@@ -1,0 +1,2 @@
+//push new version
+db.candidates.update({candidate:"groovy"}, {"$push": {versions: {version: "2.1.6", url: "http://dl.bintray.com/groovy/maven/groovy-binary-2.1.6.zip"}}});

--- a/groovy/groovy_2_1_7.js
+++ b/groovy/groovy_2_1_7.js
@@ -1,0 +1,2 @@
+//push new version
+db.candidates.update({candidate:"groovy"}, {"$push": {versions: {version: "2.1.7", url: "http://dl.bintray.com/groovy/maven/groovy-binary-2.1.7.zip"}}});

--- a/groovy/groovy_2_1_8.js
+++ b/groovy/groovy_2_1_8.js
@@ -1,0 +1,2 @@
+//push new version
+db.candidates.update({candidate:"groovy"}, {"$push": {versions: {version: "2.1.8", url: "http://dl.bintray.com/groovy/maven/groovy-binary-2.1.8.zip"}}});

--- a/groovy/groovy_2_1_9.js
+++ b/groovy/groovy_2_1_9.js
@@ -1,0 +1,2 @@
+//push new version
+db.candidates.update({candidate:"groovy"}, {"$push": {versions: {version: "2.1.9", url: "http://dl.bintray.com/groovy/maven/groovy-binary-2.1.9.zip"}}});

--- a/groovy/groovy_2_2_0.js
+++ b/groovy/groovy_2_2_0.js
@@ -1,0 +1,2 @@
+//push new version
+db.candidates.update({candidate:"groovy"}, {"$push": {versions: {version: "2.2.0", url: "http://dl.bintray.com/groovy/maven/groovy-binary-2.2.0.zip"}}});


### PR DESCRIPTION
This should fix both gvmtool/gvm-cli#332 and gvmtool/gvm-cli#331